### PR TITLE
Update lua-event.c

### DIFF
--- a/levent/lua-event.c
+++ b/levent/lua-event.c
@@ -8,6 +8,8 @@
 #include "lua.h"
 #include "lauxlib.h"
 
+#define LUA_OK 0
+
 #include "ev.h"
 
 #define LOOP_METATABLE "loop_metatable"


### PR DESCRIPTION
在make时，报/opt/ds/lua/levent/levent/lua-event.c:79: 错误：‘LUA_OK’未声明(在此函数

内第一次使用)，我的Lua版本是5.1，lua.h中没有LUA_OK的定义，所以在levent/levent.c中增加
# define LUA_OK 0，编译通过。
