### PR TITLE
bugfix: bad argument #1 to 'func' (socket_metatable expected, got table)

### DIFF
--- a/levent/socket.lua
+++ b/levent/socket.lua
@@ -113,8 +113,9 @@ function Socket:accept()
 end
 
 function Socket:_recv(func, ...)
+    local cobj = self.cobj
     while true do
-        local data, err = func(self.cobj, ...)
+        local data, err = func(cobj, ...)
         if data then
             return data
         end
@@ -141,8 +142,9 @@ function Socket:recv(len)
 end
 
 function Socket:_send(func, ...)
+    local cobj = self.cobj
     while true do
-        local nwrite, err = func(self.cobj, ...)
+        local nwrite, err = func(cobj, ...)
         if nwrite then
             return nwrite
         end


### PR DESCRIPTION
在_recv或_send中，由于func是对应的c接口的引用，当触发close时，closed_socket会替换掉self.cobj，_wait挂起恢复后调用func会触发参数类型错误