### PR TITLE
handle getaddrinfo failed correctly

### DIFF
--- a/src/lua-socket.c
+++ b/src/lua-socket.c
@@ -272,8 +272,7 @@ _sock_connect(lua_State *L) {
 
     err = _getsockaddrarg(sock, host, port, &res);
     if(err != 0) {
-        lua_pushinteger(L, err);
-        return 1;
+        return _push_result(L, err);
     }
 
     err = connect(sock->fd, res->ai_addr, res->ai_addrlen);
@@ -418,8 +417,7 @@ _sock_bind(lua_State *L) {
 
     err = _getsockaddrarg(sock, host, port, &res);
     if(err != 0) {
-        lua_pushinteger(L, err);
-        return 1;
+        return _push_result(L, err);
     }
 
     err = bind(sock->fd, res->ai_addr, res->ai_addrlen);

--- a/tests/test_socket.lua
+++ b/tests/test_socket.lua
@@ -3,11 +3,14 @@ local socket = require "levent.socket"
 local timeout = require "levent.timeout"
 
 local test_data = "hello"
-function client()
+function client(host)
     local sock, errcode = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     assert(sock, errcode)
     print("begin connect:", sock:fileno())
-    assert(sock:connect("220.181.57.216", 8859))
+    local ok, exception = sock:connect(host, 8859)
+    if not ok then
+        error("connect failed:" .. exception)
+    end
     print("connect succeed")
     sock:sendall(test_data)
     sock:close()
@@ -28,7 +31,8 @@ function start()
 
     sock:listen()
     sock:set_timeout(10)
-    levent.spawn(client)
+    levent.spawn(client, "127.0.0.1")
+    levent.spawn(client, "localhost")
     print("begin accept:", sock:fileno())
     local csock, err = sock:accept()
     assert(csock, err)


### PR DESCRIPTION
`connect` / `bind` 接口处理非 numeric host 行为不正确。lua 层可能错误以为连接成功。