### PR TITLE
fix util.read_full dont return when cannot read data anymore

### DIFF
--- a/levent/socket_util.lua
+++ b/levent/socket_util.lua
@@ -49,6 +49,9 @@ function util.read_full(sock, length)
         if not ret then
             return nil, err
         end 
+        if #ret == 0 then
+            return nil -- the peer may closed or shutdown write
+        end
 
         reply = reply .. ret
     end 

--- a/levent/socket_util.lua
+++ b/levent/socket_util.lua
@@ -50,7 +50,7 @@ function util.read_full(sock, length)
             return nil, err
         end 
         if #ret == 0 then
-            return nil -- the peer may closed or shutdown write
+            return reply, true -- EOF
         end
 
         reply = reply .. ret


### PR DESCRIPTION
晓靖老师：
  之前聊的对 levent 的接收数据的优化，最近进行了。先说结论 `util.read_full` 在压测环境下性能很高，比在 Lua C 扩展写的 TCP 接收缓冲区性能还好。`util.read_full` 现在有一个问题就是在对端关闭了 socket 或者 shutdown write 后就无法返回了，所以加了个判断用于 return 出去。
  为什么 `util.read_full` 在压测环境下性能更好？我自己做的测试也是依据我们游戏服最大数据长度是 64K 。我们是在 ubuntu 系统下，所以 `util.read_full` 中变长数组中最大长度是 64K （当然在 Windows mingw 环境下这里可能会崩溃）。然后一直读取直到达到指定字节数。我们游戏的压测环境下，levent 作为机器人每时每刻都收到大量的数据，所以 TCP 缓冲区中始终都有数据，这样可以很高效的读取指定字节数，而避免 `reply = reply .. ret` 执行过多。所以 `util.read_full` 很适合在压测环境下处理数据接收。之前 tadpole 中 tools 模块下的 net/tcp.lua 每次 recv 4096 字节，然后在 lua 层面通过字符串拼接做 TCP 分包处理，显然很低效。
  以后有时间会用 `util.read_full` 在我们游戏压测下实际试试，我觉得应该不会比已有的那一版的 C 缓存差，后面会可能直接切成 `util.read_full` 。
  因此，我写好的 lua 版本的字节流缓冲区管理也就不太需要了，所以就不 push 过来了。