### PR TITLE
feature unlock multi thread ability and fix test_waiter.lua

### DIFF
--- a/levent/hub.lua
+++ b/levent/hub.lua
@@ -10,11 +10,11 @@ local Hub = class("Hub")
 
 local cancel_wait_error = exceptions.CancelWaitError.new()
 
-function Hub:_init(nt)
+function Hub:_init()
     local co, main = coroutine.running()
     assert(main, "must in main coroutine")
     self.co = co
-    self.loop = loop.new(nt)
+    self.loop = loop.new()
     self.waiters = setmetatable({}, {__mode="v"})
 end
 

--- a/levent/hub.lua
+++ b/levent/hub.lua
@@ -10,11 +10,11 @@ local Hub = class("Hub")
 
 local cancel_wait_error = exceptions.CancelWaitError.new()
 
-function Hub:_init()
+function Hub:_init(nt)
     local co, main = coroutine.running()
     assert(main, "must in main coroutine")
     self.co = co
-    self.loop = loop.new()
+    self.loop = loop.new(nt)
     self.waiters = setmetatable({}, {__mode="v"})
 end
 
@@ -130,6 +130,5 @@ function Waiter:get()
     end
 end
 
-local hub = Hub.new()
-return hub
+return Hub
 

--- a/levent/levent.lua
+++ b/levent/levent.lua
@@ -14,7 +14,7 @@ local levent = {}
 
 levent.kill_error = kill_error
 
-local hub = false
+local hub = hub_class.new()
 
 function levent.now()
     return hub.loop:now()
@@ -62,18 +62,7 @@ function levent.kill(co)
     hub.loop:run_callback(hub.throw, hub, co, kill_error)
 end
 
--- use default event loop
 function levent.start(f, ...)
-    assert(hub == false)
-    hub = hub_class.new()
-    levent.spawn(f, ...)
-    hub:run()
-end
-
--- create new event loop
-function levent.start_new_loop(f, ...)
-    assert(hub == false)
-    hub = hub_class.new(true)
     levent.spawn(f, ...)
     hub:run()
 end

--- a/levent/levent.lua
+++ b/levent/levent.lua
@@ -2,7 +2,9 @@
 -- author: xjdrew
 -- date: 2014-07-17
 --]]
-local hub        = require "levent.hub"
+local assert     = assert
+
+local hub_class  = require "levent.hub"
 local coroutines = require "levent.coroutines"
 local exceptions = require "levent.exceptions"
 
@@ -11,6 +13,8 @@ local kill_error = exceptions.KillError.new()
 local levent = {}
 
 levent.kill_error = kill_error
+
+local hub = false
 
 function levent.now()
     return hub.loop:now()
@@ -58,7 +62,18 @@ function levent.kill(co)
     hub.loop:run_callback(hub.throw, hub, co, kill_error)
 end
 
+-- use default event loop
 function levent.start(f, ...)
+    assert(hub == false)
+    hub = hub_class.new()
+    levent.spawn(f, ...)
+    hub:run()
+end
+
+-- create new event loop
+function levent.start_new_loop(f, ...)
+    assert(hub == false)
+    hub = hub_class.new(true)
     levent.spawn(f, ...)
     hub:run()
 end

--- a/levent/lock.lua
+++ b/levent/lock.lua
@@ -3,8 +3,8 @@
 -- date: 2014-07-31
 --]]
 
+local levent     = require "levent.levent"
 local class      = require "levent.class"
-local hub        = require "levent.hub"
 local timeout    = require "levent.timeout"
 local exceptions = require "levent.exceptions"
 
@@ -22,6 +22,7 @@ function Event:_init()
 end
 
 function Event:set()
+    local hub = levent.get_hub()
     self.flag = true
     for k,v in pairs(self.links) do
         self.todo[k] = v
@@ -42,6 +43,7 @@ function Event:wait(sec)
         return self.flag
     end
 
+    local hub = levent.get_hub()
     local waiter = hub:waiter()
     self.links[waiter] = true
 
@@ -78,6 +80,7 @@ function AsyncResult:_init()
 end
 
 function AsyncResult:_set(val, exception)
+    local hub = levent.get_hub()
     assert(self.exception == false, "repeated set result")
     self.value = val
     self.exception = exception
@@ -94,6 +97,7 @@ function AsyncResult:set_exception(exception)
 end
 
 function AsyncResult:get(sec)
+    local hub = levent.get_hub()
     if self.exception == false then
         local t = timeout.start_new(sec)
         local waiter = hub:waiter()
@@ -137,6 +141,7 @@ function Semaphore:locked()
 end
 
 function Semaphore:release()
+    local hub = levent.get_hub()
     self.counter = self.counter + 1
     if not self.notifier and next(self.links) then
         self.notifier = true
@@ -149,6 +154,7 @@ function Semaphore:wait(sec)
         return true
     end
     
+    local hub = levent.get_hub()
     local waiter = hub:waiter()
     self.links[waiter] = true
 

--- a/levent/loop.lua
+++ b/levent/loop.lua
@@ -87,8 +87,8 @@ function Watcher:__gc()
 end
 
 local Loop = class("Loop")
-function Loop:_init()
-    self.cobj = ev.default_loop()
+function Loop:_init(nt)
+    self.cobj = nt and ev.new_loop() or ev.default_loop()
     self.watchers = setmetatable({}, {__mode="v"})
 
     -- register prepare
@@ -172,8 +172,10 @@ function Loop:handle_error(watcher, msg)
 end
 
 local loop = {}
-function loop.new()
-    local obj = Loop.new()
+
+-- nt: use new thread
+function loop.new(nt)
+    local obj = Loop.new(nt)
     for k,v in pairs(ev) do
         if type(v) ~= "function" then
             obj[k] = v

--- a/levent/loop.lua
+++ b/levent/loop.lua
@@ -87,8 +87,8 @@ function Watcher:__gc()
 end
 
 local Loop = class("Loop")
-function Loop:_init(nt)
-    self.cobj = nt and ev.new_loop() or ev.default_loop()
+function Loop:_init()
+    self.cobj = ev.new_loop()
     self.watchers = setmetatable({}, {__mode="v"})
 
     -- register prepare
@@ -173,9 +173,8 @@ end
 
 local loop = {}
 
--- nt: use new thread
-function loop.new(nt)
-    local obj = Loop.new(nt)
+function loop.new()
+    local obj = Loop.new()
     for k,v in pairs(ev) do
         if type(v) ~= "function" then
             obj[k] = v

--- a/levent/queue.lua
+++ b/levent/queue.lua
@@ -3,8 +3,8 @@
 -- date: 2014-08-08
 --]]
 
+local levent  = require "levent.levent"
 local class   = require "levent.class"
-local hub     = require "levent.hub"
 local timeout = require "levent.timeout"
 local lock    = require "levent.lock"
 
@@ -73,6 +73,7 @@ function Queue:__len()
 end
 
 function Queue:_get()
+    local hub = levent.get_hub()
     assert(self.length > 0)
     local item = table.remove(self.items, 1)
     self.length = self.length - 1
@@ -84,6 +85,7 @@ function Queue:_get()
 end
 
 function Queue:_put(item)
+    local hub = levent.get_hub()
     self.length = self.length + 1
     self.items[self.length] = item
     self.cond:clear()
@@ -98,6 +100,7 @@ function Queue:put(item, sec)
         self:_put(item)
         return
     end
+    local hub = levent.get_hub()
     local waiter = hub:waiter()
     self.putters[waiter] = true
 
@@ -115,6 +118,7 @@ function Queue:get(sec)
     if self.length > 0 then
         return self:_get()
     end
+    local hub = levent.get_hub()
     local waiter = hub:waiter()
     self.getters[waiter] = true
 

--- a/levent/select.lua
+++ b/levent/select.lua
@@ -2,9 +2,9 @@
 -- author: xjdrew
 -- date: 2014-08-13
 --]]
-local hub   = require "levent.hub"
-local class = require "levent.class"
-local lock  = require "levent.lock"
+local levent    = require "levent.levent"
+local class     = require "levent.class"
+local lock      = require "levent.lock"
 
 local function get_fileno(obj)
     local fileno
@@ -57,6 +57,7 @@ end
 
 local function select_(rlist, wlist, xlist, sec)
     local watchers = {}
+    local hub = levent.get_hub()
     local loop = hub.loop
     local MAXPRI = loop.EV_MAXPRI
     local result = SelectResult.new()

--- a/levent/signal.lua
+++ b/levent/signal.lua
@@ -3,12 +3,13 @@
 -- date: 2014-08-14
 --]]
 
-local hub   = require "levent.hub"
-local class = require "levent.class"
+local levent    = require "levent.levent"
+local class     = require "levent.class"
 
 local Signal = class("Signal")
 
 function Signal:_init(signum, handler, ...)
+    local hub = levent.get_hub()
     self.watcher = hub.loop:signal(signum)
     self.watcher:start(handler, ...)
 end

--- a/levent/timeout.lua
+++ b/levent/timeout.lua
@@ -1,4 +1,4 @@
-local hub        = require "levent.hub"
+local levent     = require "levent.levent"
 local class      = require "levent.class"
 local exceptions = require "levent.exceptions"
 
@@ -9,10 +9,12 @@ function Timeout:_init(seconds)
     if not self.seconds or self.seconds <= 0 then
         return
     end
+    local hub = levent.get_hub()
     self.timer = hub.loop:timer(self.seconds)
 end
 
 function Timeout:start()
+    local hub = levent.get_hub()
     if self.timer then
         local co = coroutine.running()
         self.timer:start(hub.throw, hub, co, self)

--- a/tests/test_waiter.lua
+++ b/tests/test_waiter.lua
@@ -19,7 +19,8 @@ function t2()
     print(value)
 end
 
-levent.spawn(t1)
-levent.spawn(t2)
-levent.wait()
+levent.start(function()
+    levent.spawn(t1)
+    levent.spawn(t2)
+end)
 


### PR DESCRIPTION
晓靖老师：
  新加了一个 feature 解锁 levent 的多线程的能力，之前提交的是带一个 lua 线程库的，但想了一下这样太重了，只需要解锁 levent 的多线程能力即可，使用者根据自己的需要选择线程即可，推荐使用 [effil](https://github.com/effil/effil) 。

如何在多线程中使用 levent 呢？
新增了 `levent.start_new_loop` 函数，说明一下**任何使用 `levent.start` 的地方都可以用 `levent.start_new_loop`** 。多线程使用有两种方式：

* 主线程使用 `levent.start` （这样是采用 libev 创建的默认的 event loop ），子线程使用 `levent.start_new_loop` 函数。
* 全部使用 `levent.start_new_loop` 每次都创建新的 event loop 即可，这样就不用区分 `levent.start` 中创建的默认的 event loop 了。

```lua
-- create new event loop
function levent.start_new_loop(f, ...)
    assert(hub == false)
    hub = hub_class.new(true)
    levent.spawn(f, ...)         
    hub:run()              
end                         
```

我们项目中已经是在多线程环境下使用 levent 来增加机器人的处理能力。