### PR TITLE
fix libev build in macosx m1

### DIFF
--- a/deps/libev/config.sub
+++ b/deps/libev/config.sub
@@ -253,7 +253,7 @@ case $basic_machine in
 	| alpha64 | alpha64ev[4-8] | alpha64ev56 | alpha64ev6[78] | alpha64pca5[67] \
 	| am33_2.0 \
 	| arc | arceb \
-	| arm | arm[bl]e | arme[lb] | armv[2-8] | armv[3-8][lb] | armv7[arm] \
+	| arm | arm[bl]e | arme[lb] | armv[2-8] | armv[3-8][lb] | armv7[arm] | arm64-* \
 	| avr | avr32 \
 	| be32 | be64 \
 	| bfin \


### PR DESCRIPTION
fix 在使用macosx arm cpu编译时报错：
```
checking build system type... Invalid configuration `arm64-apple-darwin22.5.0': machine `arm64-apple' not recognized
configure: error: /bin/sh ./config.sub arm64-apple-darwin22.5.0 failed
```