### PR TITLE
修复连接被对端断开时候的解析异常

### DIFF
--- a/levent/http/util.lua
+++ b/levent/http/util.lua
@@ -11,8 +11,12 @@ function util.read_message(conn, parser, left)
             s = left
         else
             s, err = conn:recv(4096)
-            if not s then
+            if err then
                 return nil, err
+            end
+            if (not s) or (#s == 0) then
+                -- socket closed by peer
+                return nil, ""
             end
         end
 

--- a/levent/http/util.lua
+++ b/levent/http/util.lua
@@ -8,7 +8,7 @@ function util.read_message(conn, parser, left)
     repeat
         local parsed, s, err
         if left then
-            s = left
+            s, left = left, nil
         else
             s, err = conn:recv(4096)
             if not s then
@@ -16,20 +16,11 @@ function util.read_message(conn, parser, left)
             end
         end
 
-        if #s > 0 and not msg then
-            -- first time we have data
-            msg = {}
+        if #s == 0 then
+            break
         end
 
-        if #s == 0 then
-            -- socket closed by peer
-            if msg then
-                -- partial data
-                break
-            else
-                return nil, ""
-            end
-        end
+        msg = msg or {}
 
         parsed, err = parser:execute(s, nil, msg)
         if err then


### PR DESCRIPTION
复现场景，在一条连接上收发多个http请求，如果后面连接被对端断开，会有解析报错。